### PR TITLE
add run-export

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - 0001-Disable-GNU_SOURCE.patch
 
 build:
-  number: 1
+  number: 2
   skip: true  # [win]
   run_exports:
     # https://abi-laboratory.pro/tracker/timeline/opusfile

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,9 @@ source:
 build:
   number: 1
   skip: true  # [win]
+  run_exports:
+    # https://abi-laboratory.pro/tracker/timeline/opusfile
+    - {{ pin_subpackage("opusfile", max_pin="x.x") }}
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,10 +28,6 @@ requirements:
     - libopus
     - libogg
     - openssl
-  run:
-    - libopus
-    - libogg
-    - openssl
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,12 +1,11 @@
-{% set name = "opusfile" %}
 {% set version = "0.12" %}
 
 package:
-  name: {{ name }}
+  name: opusfile
   version: {{ version }}
 
 source:
-  url: https://ftp.osuosl.org/pub/xiph/releases/opus/{{ name }}-{{ version }}.tar.gz
+  url: https://ftp.osuosl.org/pub/xiph/releases/opus/opusfile-{{ version }}.tar.gz
   sha256: 118d8601c12dd6a44f52423e68ca9083cc9f2bfe72da7a8c1acb22a80ae3550b
   patches:
     # https://github.com/conda/conda-build/issues/3165


### PR DESCRIPTION
run-exports are now standard in conda-forge. libraries (resp. packages like opusfile) should provide them, and can themselves rely on those of their host dependencies.